### PR TITLE
Update eval harness to operate on opaque galleries

### DIFF
--- a/include/iarpa_janus_io.h
+++ b/include/iarpa_janus_io.h
@@ -189,11 +189,11 @@ JANUS_EXPORT janus_error janus_create_templates(const char *data_path, janus_met
  * \brief High-level function for enrolling a gallery from a metadata file.
  * \param [in] data_path Prefix path to files in metadata.
  * \param [in] metadata #janus_metadata to enroll.
- * \param [in] gallery File to save the templates to.
+ * \param [in] gallery_path Path to gallery folder.
  * \param [in] verbose Print information and warnings during gallery enrollment.
  * \remark This function is \ref thread_unsafe.
  */
-JANUS_EXPORT janus_error janus_create_gallery(const char *data_path, janus_metadata metadata, janus_gallery gallery, int verbose);
+JANUS_EXPORT janus_error janus_create_gallery(const char *data_path, janus_metadata metadata, janus_gallery_path gallery_path, int verbose);
 
 /*!
  * \brief A dense binary 2D matrix file.
@@ -221,8 +221,7 @@ JANUS_EXPORT janus_error janus_write_matrix(void *data, int rows, int columns, i
  * \brief Create similarity and mask matricies from two galleries with calls to janus_search.
  *
  * The \c SUBJECT_ID field is used to determine ground truth match/non-match in the mask.
- * \param[in] target flat_gallery to constitute the columns of the matrix.
- * \param[in] target_bytes size of target gallery.
+ * \param[in] target Path to gallery being seached against on disk.
  * \param[in] query Templates file created fron janus_create_templates to constitute the rows for the matrix.
  * \param[in] target_metadata metadata file for \p target.
  * \param[in] query_metadata metadata file for \p query.
@@ -231,7 +230,7 @@ JANUS_EXPORT janus_error janus_write_matrix(void *data, int rows, int columns, i
  * \param[in] num_requested_returns Desired number of returned results for each call to janus_search.
  * \remark This function is \ref thread_unsafe.
  */
-JANUS_EXPORT janus_error janus_evaluate_search(janus_flat_gallery target, size_t target_bytes, const char *query, janus_metadata target_metadata, janus_metadata query_metadata, janus_matrix simmat, janus_matrix mask, size_t num_requested_returns);
+JANUS_EXPORT janus_error janus_evaluate_search(janus_gallery_path target, const char *query, janus_metadata target_metadata, janus_metadata query_metadata, janus_matrix simmat, janus_matrix mask, size_t num_requested_returns);
 
 /*!
  * \brief Create similarity and mask matricies from two galleries with calls to janus_verify.

--- a/src/pittpatt/pittpatt.cpp
+++ b/src/pittpatt/pittpatt.cpp
@@ -358,7 +358,9 @@ janus_error janus_open_gallery(janus_gallery_path gallery_path, janus_gallery *g
         templates_ += template_bytes;
 
         ppr_unflatten(flat_template, template_bytes, &(*gallery)->ppr_gallery, template_id);
+        delete[] flat_template;
     }
+    delete[] templates;
     return JANUS_SUCCESS;
 }
 

--- a/src/utils/janus_create_gallery.cpp
+++ b/src/utils/janus_create_gallery.cpp
@@ -13,7 +13,7 @@ const char *get_ext(const char *filename) {
 
 void printUsage()
 {
-    printf("Usage: janus_create_gallery sdk_path temp_path data_path metadata_file gallery_file [-algorithm <algorithm>] [-verbose]\n");
+    printf("Usage: janus_create_gallery sdk_path temp_path data_path metadata_file gallery_path [-algorithm <algorithm>] [-verbose]\n");
 }
 
 int main(int argc, char *argv[])
@@ -26,12 +26,8 @@ int main(int argc, char *argv[])
     }
 
     const char *ext1 = get_ext(argv[4]);
-    const char *ext2 = get_ext(argv[5]);
     if (strcmp(ext1, "csv") != 0) {
         printf("metadata_file must be \".csv\" format.\n");
-        return 1;
-    } else if (strcmp(ext2, "gal") != 0) {
-        printf("gallery_file must be \".gal\" format. \n");
         return 1;
     }
 
@@ -50,22 +46,10 @@ int main(int argc, char *argv[])
 
     JANUS_ASSERT(janus_initialize(argv[1], argv[2], algorithm))
 
-    janus_gallery gallery;
-    JANUS_ASSERT(janus_allocate_gallery(&gallery))
+    JANUS_ASSERT(janus_create_gallery(argv[3], argv[4], argv[5], verbose))
+    janus_print_metrics(janus_get_metrics());
 
-    JANUS_ASSERT(janus_create_gallery(argv[3], argv[4], gallery, verbose))
-
-    janus_metrics metrics = janus_get_metrics();
-    size_t size = metrics.janus_initialize_template_speed.count;
-    janus_flat_gallery flat_gallery = new janus_data[size*janus_max_template_size()];
-    size_t bytes;
-    JANUS_ASSERT(janus_flatten_gallery(gallery, flat_gallery, &bytes))
-    std::ofstream file;
-    file.open(argv[5], std::ios::out | std::ios::binary);
-    file.write((char*)flat_gallery, bytes);
-    file.close();
     JANUS_ASSERT(janus_finalize())
 
-    janus_print_metrics(metrics);
     return EXIT_SUCCESS;
 }

--- a/src/utils/janus_evaluate_search.cpp
+++ b/src/utils/janus_evaluate_search.cpp
@@ -25,23 +25,23 @@ int main(int argc, char *argv[])
         printUsage();
         return 1;
     }
-    const char *ext1 = get_ext(argv[3]);
-    const char *ext2 = get_ext(argv[4]);
-    const char *ext3 = get_ext(argv[6]);
-    const char *ext4 = get_ext(argv[6]);
-    const char *ext5 = get_ext(argv[7]);
-    const char *ext6 = get_ext(argv[8]);
 
-    if (strcmp(ext1, "gal") != 0 || strcmp(ext2, "gal") != 0) {
-        printf("Gallery files must be \".gal\" format.\n");
+    const char *ext1 = get_ext(argv[4]);
+    const char *ext2 = get_ext(argv[5]);
+    const char *ext3 = get_ext(argv[6]);
+    const char *ext4 = get_ext(argv[7]);
+    const char *ext5 = get_ext(argv[8]);
+
+    if (strcmp(ext1, "gal") != 0) {
+        printf("Query gallery file must be \".gal\" format.\n");
         return 1;
-    } else if (strcmp(ext3, "csv") != 0 || strcmp(ext4, "csv") != 0) {
+    } else if (strcmp(ext2, "csv") != 0 || strcmp(ext3, "csv") != 0) {
         printf("Metadata files must be \".csv\" format. \n");
         return 1;
-    } else if (strcmp(ext5, "mtx") != 0) {
+    } else if (strcmp(ext4, "mtx") != 0) {
         printf("Similarity matrix files should be \".mtx\" format.");
         return 1;
-    } else if (strcmp(ext6, "mask") != 0) {
+    } else if (strcmp(ext5, "mask") != 0) {
         printf("Mask matrix files should be \".mask\" format.");
         return 1;
     }
@@ -58,15 +58,7 @@ int main(int argc, char *argv[])
     JANUS_ASSERT(janus_initialize(argv[1], argv[2], algorithm))
     size_t num_requested_returns = atoi(argv[9]);
 
-    std::ifstream target;
-    target.open(argv[3], std::ios::binary | std::ios::ate);
-    size_t target_bytes = target.tellg();
-    target.seekg(0, ios::beg);
-
-    janus_flat_gallery target_flat = new janus_data[target_bytes];
-    target.read((char*)target_flat, target_bytes);
-
-    JANUS_ASSERT(janus_evaluate_search(target_flat, target_bytes, argv[4], argv[5], argv[6], argv[7], argv[8], num_requested_returns))
+    JANUS_ASSERT(janus_evaluate_search(argv[3], argv[4], argv[5], argv[6], argv[7], argv[8], num_requested_returns))
     JANUS_ASSERT(janus_finalize())
 
     janus_print_metrics(janus_get_metrics());


### PR DESCRIPTION
This PR includes updates introduced by the API changes in #18.  In addition to:
* `janus_create_gallery` now takes `janus_gallery_path` as a parameter instead of `janus_gallery`.  The gallery is now finalized and written to disk with a call to `janus_write_gallery`.

* `janus_evaluate_search` now takes `janus_gallery_path` instead of `janus_flat_gallery` for the target search gallery.  The gallery is initialized with `janus_open_gallery`.