### PR TITLE
Add janus_verify_pairwise

### DIFF
--- a/include/iarpa_janus_io.h
+++ b/include/iarpa_janus_io.h
@@ -247,6 +247,17 @@ JANUS_EXPORT janus_error janus_evaluate_search(janus_gallery_path target, const 
 JANUS_EXPORT janus_error janus_evaluate_verify(const char *target, const char *query, janus_metadata target_metadata, janus_metadata query_metadata, janus_matrix simmat, janus_matrix mask);
 
 /*!
+ * \brief High-level function for executing a list of template comparisons with results output in NIST IJB-A format.
+ *
+ * Refer to [<b>face.nist.gov</b>](http://www.nist.gov/itl/iad/ig/face.cfm) for more information on IJB-A.
+ * \param[in] comparisons_file File containing the list of template comparisons to make.
+ * \param[in] templates_file Templates file created from janus_create_templates containing the comparison templates.
+ * \param[in] match_scores Output matches file with template size and score recorded for each comparison.
+ * \remark This function is \ref thread_unsafe.
+ */
+JANUS_EXPORT janus_error janus_verify_pairwise(const char *comparisons_file, const char *templates_file, const char *match_scores);
+
+/*!
  * \brief A statistic.
  * \see janus_metrics
  */

--- a/include/iarpa_janus_io.h
+++ b/include/iarpa_janus_io.h
@@ -221,16 +221,18 @@ JANUS_EXPORT janus_error janus_write_matrix(void *data, int rows, int columns, i
  * \brief Create similarity and mask matricies from two galleries with calls to janus_search.
  *
  * The \c SUBJECT_ID field is used to determine ground truth match/non-match in the mask.
+ * Refer to <a href="http://www.nist.gov/itl/iad/ig/face.cfm"><b>face.nist.gov</b></a> for more information on IJB-A and the ".candidate_lists" format.
  * \param[in] target Path to gallery being seached against on disk.
  * \param[in] query Templates file created fron janus_create_templates to constitute the rows for the matrix.
  * \param[in] target_metadata metadata file for \p target.
  * \param[in] query_metadata metadata file for \p query.
  * \param[in] simmat Similarity matrix file to be created.
  * \param[in] mask Mask matrix file to be created.
+ * \param[in] candidate_lists Text file containing template size and score for each search's requested returns.
  * \param[in] num_requested_returns Desired number of returned results for each call to janus_search.
  * \remark This function is \ref thread_unsafe.
  */
-JANUS_EXPORT janus_error janus_evaluate_search(janus_gallery_path target, const char *query, janus_metadata target_metadata, janus_metadata query_metadata, janus_matrix simmat, janus_matrix mask, size_t num_requested_returns);
+JANUS_EXPORT janus_error janus_evaluate_search(janus_gallery_path target, const char *query, janus_metadata target_metadata, janus_metadata query_metadata, janus_matrix simmat, janus_matrix mask, const char *candidate_lists, size_t num_requested_returns);
 
 /*!
  * \brief Create similarity and mask matricies from two galleries with calls to janus_verify.

--- a/include/iarpa_janus_io.h
+++ b/include/iarpa_janus_io.h
@@ -247,15 +247,18 @@ JANUS_EXPORT janus_error janus_evaluate_search(janus_gallery_path target, const 
 JANUS_EXPORT janus_error janus_evaluate_verify(const char *target, const char *query, janus_metadata target_metadata, janus_metadata query_metadata, janus_matrix simmat, janus_matrix mask);
 
 /*!
- * \brief High-level function for executing a list of template comparisons with results output in NIST IJB-A format.
+ * \brief High-level function for executing a list of template comparisons.
  *
- * Refer to [<b>face.nist.gov</b>](http://www.nist.gov/itl/iad/ig/face.cfm) for more information on IJB-A.
+ * Refer to <a href="http://www.nist.gov/itl/iad/ig/face.cfm"><b>face.nist.gov</b></a> for more information on IJB-A and the ".matches" format.
  * \param[in] comparisons_file File containing the list of template comparisons to make.
  * \param[in] templates_file Templates file created from janus_create_templates containing the comparison templates.
+ * \param[in] template_metadata metadata file for comparison templates.
+ * \param[in] simmat Similarity matrix file to be created.
+ * \param[in] mask Mask matrix file to be created.
  * \param[in] match_scores Output matches file with template size and score recorded for each comparison.
  * \remark This function is \ref thread_unsafe.
  */
-JANUS_EXPORT janus_error janus_verify_pairwise(const char *comparisons_file, const char *templates_file, const char *match_scores);
+JANUS_EXPORT janus_error janus_verify_pairwise(const char *comparisons_file, const char *templates_file, janus_metadata template_metadata, janus_matrix simmat, janus_matrix mask, const char *match_scores);
 
 /*!
  * \brief A statistic.

--- a/src/utils/ijba_verify.cpp
+++ b/src/utils/ijba_verify.cpp
@@ -1,0 +1,59 @@
+#include <stdlib.h>
+#include <string.h>
+#include <fstream>
+
+#include "iarpa_janus.h"
+#include "iarpa_janus_io.h"
+using namespace std;
+
+
+const char *get_ext(const char *filename) {
+    const char *dot = strrchr(filename, '.');
+    if (!dot || dot == filename) return "";
+    return dot + 1;
+}
+
+void printUsage()
+{
+    printf("Usage: ijba_verify sdk_path temp_path comparison_list templates match_scores [-algorithm <algorithm>]\n");
+}
+
+int main(int argc, char *argv[])
+{
+    int requiredArgs = 6;
+
+    if ((argc < requiredArgs) || (argc > 8)) {
+        printUsage();
+        return 1;
+    }
+    const char *ext1 = get_ext(argv[3]);
+    const char *ext2 = get_ext(argv[4]);
+    const char *ext3 = get_ext(argv[5]);
+
+    if (strcmp(ext1, "csv") != 0) {
+        printf("Comparison list must be \".csv\" format.");
+        return 1;
+    } else if (strcmp(ext2, "gal") != 0) {
+        printf("Templates file must be \".gal\" format.");
+        return 1;
+    } else if (strcmp(ext3, "matches") != 0) {
+        printf("Match scores must be output in \".matches\" format.");
+        return 1;
+    }
+
+    char *algorithm = NULL;
+    for (int i=0; i<argc-requiredArgs; i++)
+        if (strcmp(argv[requiredArgs+i], "-algorithm") == 0)
+            algorithm = argv[requiredArgs+(++i)];
+        else {
+            fprintf(stderr, "Unrecognized flag: %s\n", argv[requiredArgs+i]);
+            return 1;
+        }
+
+    JANUS_ASSERT(janus_initialize(argv[1], argv[2], algorithm))
+    JANUS_ASSERT(janus_verify_pairwise(argv[3], argv[4], argv[5]))
+    JANUS_ASSERT(janus_finalize())
+
+    janus_print_metrics(janus_get_metrics());
+    return EXIT_SUCCESS;
+}

--- a/src/utils/janus_evaluate_search.cpp
+++ b/src/utils/janus_evaluate_search.cpp
@@ -14,14 +14,14 @@ const char *get_ext(const char *filename) {
 
 void printUsage()
 {
-    printf("Usage: janus_evaluate_search sdk_path temp_path target_gallery query_gallery target_metadata query_metadata simmat mask num_returns [-algorithm <algorithm>]\n");
+    printf("Usage: janus_evaluate_search sdk_path temp_path target_gallery query_gallery target_metadata query_metadata simmat mask candidate_lists num_returns [-algorithm <algorithm>]\n");
 }
 
 int main(int argc, char *argv[])
 {
-    int requiredArgs = 10;
+    int requiredArgs = 11;
 
-    if ((argc < requiredArgs) || (argc > 12)) {
+    if ((argc < requiredArgs) || (argc > 13)) {
         printUsage();
         return 1;
     }
@@ -31,6 +31,7 @@ int main(int argc, char *argv[])
     const char *ext3 = get_ext(argv[6]);
     const char *ext4 = get_ext(argv[7]);
     const char *ext5 = get_ext(argv[8]);
+    const char *ext6 = get_ext(argv[9]);
 
     if (strcmp(ext1, "gal") != 0) {
         printf("Query gallery file must be \".gal\" format.\n");
@@ -39,16 +40,19 @@ int main(int argc, char *argv[])
         printf("Metadata files must be \".csv\" format. \n");
         return 1;
     } else if (strcmp(ext4, "mtx") != 0) {
-        printf("Similarity matrix files should be \".mtx\" format.");
+        printf("Similarity matrix files should be \".mtx\" format.\n");
         return 1;
     } else if (strcmp(ext5, "mask") != 0) {
-        printf("Mask matrix files should be \".mask\" format.");
+        printf("Mask matrix files should be \".mask\" format.\n");
+        return 1;
+    } else if (strcmp(ext6, "candidate_lists") != 0) {
+        printf("candidate_lists must be \".candidate_lists\" format.\n");
         return 1;
     }
 
     char *algorithm = NULL;
     for (int i=0; i<argc-requiredArgs; i++)
-        if (strcmp(argv[requiredArgs+i],"-algorithm") == 0)
+        if (strcmp(argv[requiredArgs+i], "-algorithm") == 0)
             algorithm = argv[requiredArgs+(++i)];
         else {
             fprintf(stderr, "Unrecognized flag: %s\n", argv[requiredArgs+i]);
@@ -56,9 +60,9 @@ int main(int argc, char *argv[])
         }
 
     JANUS_ASSERT(janus_initialize(argv[1], argv[2], algorithm))
-    size_t num_requested_returns = atoi(argv[9]);
+    size_t num_requested_returns = atoi(argv[10]);
 
-    JANUS_ASSERT(janus_evaluate_search(argv[3], argv[4], argv[5], argv[6], argv[7], argv[8], num_requested_returns))
+    JANUS_ASSERT(janus_evaluate_search(argv[3], argv[4], argv[5], argv[6], argv[7], argv[8], argv[9], num_requested_returns))
     JANUS_ASSERT(janus_finalize())
 
     janus_print_metrics(janus_get_metrics());

--- a/src/utils/janus_evaluate_verify.cpp
+++ b/src/utils/janus_evaluate_verify.cpp
@@ -39,10 +39,10 @@ int main(int argc, char *argv[])
         printf("Metadata files must be \".csv\" format. \n");
         return 1;
     } else if (strcmp(ext5, "mtx") != 0) {
-        printf("Similarity matrix files should be \".mtx\" format.");
+        printf("Similarity matrix files should be \".mtx\" format.\n");
         return 1;
     } else if (strcmp(ext6, "mask") != 0) {
-        printf("Mask matrix files should be \".mask\" format.");
+        printf("Mask matrix files should be \".mask\" format.\n");
         return 1;
     }
 

--- a/src/utils/janus_verify_pairwise.cpp
+++ b/src/utils/janus_verify_pairwise.cpp
@@ -15,20 +15,23 @@ const char *get_ext(const char *filename) {
 
 void printUsage()
 {
-    printf("Usage: ijba_verify sdk_path temp_path comparison_list templates match_scores [-algorithm <algorithm>]\n");
+    printf("Usage: janus_verify_pairwise sdk_path temp_path comparison_list templates templates_metadata simmat mask ijba_matches [-algorithm <algorithm>]\n");
 }
 
 int main(int argc, char *argv[])
 {
-    int requiredArgs = 6;
+    int requiredArgs = 9;
 
-    if ((argc < requiredArgs) || (argc > 8)) {
+    if ((argc < requiredArgs) || (argc > 11)) {
         printUsage();
         return 1;
     }
     const char *ext1 = get_ext(argv[3]);
     const char *ext2 = get_ext(argv[4]);
     const char *ext3 = get_ext(argv[5]);
+    const char *ext4 = get_ext(argv[6]);
+    const char *ext5 = get_ext(argv[7]);
+    const char *ext6 = get_ext(argv[8]);
 
     if (strcmp(ext1, "csv") != 0) {
         printf("Comparison list must be \".csv\" format.");
@@ -36,7 +39,16 @@ int main(int argc, char *argv[])
     } else if (strcmp(ext2, "gal") != 0) {
         printf("Templates file must be \".gal\" format.");
         return 1;
-    } else if (strcmp(ext3, "matches") != 0) {
+    } else if (strcmp(ext3, "csv") != 0) {
+        printf("Metadata files must be \".csv\" format. \n");
+        return 1;
+    } else if (strcmp(ext4, "mtx") != 0) {
+        printf("Similarity matrix files should be \".mtx\" format.");
+        return 1;
+    } else if (strcmp(ext5, "mask") != 0) {
+        printf("Mask matrix files should be \".mask\" format.");
+        return 1;
+    } else if (strcmp(ext6, "matches") != 0) {
         printf("Match scores must be output in \".matches\" format.");
         return 1;
     }
@@ -51,7 +63,7 @@ int main(int argc, char *argv[])
         }
 
     JANUS_ASSERT(janus_initialize(argv[1], argv[2], algorithm))
-    JANUS_ASSERT(janus_verify_pairwise(argv[3], argv[4], argv[5]))
+    JANUS_ASSERT(janus_verify_pairwise(argv[3], argv[4], argv[5], argv[6], argv[7], argv[8]))
     JANUS_ASSERT(janus_finalize())
 
     janus_print_metrics(janus_get_metrics());

--- a/src/utils/janus_verify_pairwise.cpp
+++ b/src/utils/janus_verify_pairwise.cpp
@@ -34,22 +34,22 @@ int main(int argc, char *argv[])
     const char *ext6 = get_ext(argv[8]);
 
     if (strcmp(ext1, "csv") != 0) {
-        printf("Comparison list must be \".csv\" format.");
+        printf("Comparison list must be \".csv\" format.\n");
         return 1;
     } else if (strcmp(ext2, "gal") != 0) {
-        printf("Templates file must be \".gal\" format.");
+        printf("Templates file must be \".gal\" format.\n");
         return 1;
     } else if (strcmp(ext3, "csv") != 0) {
-        printf("Metadata files must be \".csv\" format. \n");
+        printf("Metadata files must be \".csv\" format.\n");
         return 1;
     } else if (strcmp(ext4, "mtx") != 0) {
-        printf("Similarity matrix files should be \".mtx\" format.");
+        printf("Similarity matrix files should be \".mtx\" format.\n");
         return 1;
     } else if (strcmp(ext5, "mask") != 0) {
-        printf("Mask matrix files should be \".mask\" format.");
+        printf("Mask matrix files should be \".mask\" format.\n");
         return 1;
     } else if (strcmp(ext6, "matches") != 0) {
-        printf("Match scores must be output in \".matches\" format.");
+        printf("Match scores must be output in \".matches\" format.\n");
         return 1;
     }
 


### PR DESCRIPTION
This branch adds `janus_verify_pairwise` to the evaluation harness, as well as a command line utility for executing a list of template comparisons in accordance with the [IJB-A 1:1 protocol.] (http://www.nist.gov/itl/iad/ig/facechallenges.cfm)

A `candidate_lists` parameter was also added to `janus_evaluate_search` for constructing retrieval candidate lists for NIST IJB-A 1:N evaluation.
@JordanCheney please review @jklontz fyi