### PR TITLE
Fixing a write-after-end-of-array bug in janus_evaluate_search

### DIFF
--- a/src/janus_io.cpp
+++ b/src/janus_io.cpp
@@ -556,7 +556,6 @@ janus_error janus_evaluate_search(janus_gallery_path target, const char *query, 
 
         // Write matrix of size num_queries*num_requested returns
         if (num_actual_returns < num_requested_returns) {
-            int diff = num_requested_returns - num_actual_returns;
             memcpy(similarity_matrix, similarities, sizeof(float)*num_actual_returns);
 
             for (size_t i=num_actual_returns; i<num_requested_returns; i++) {

--- a/src/janus_io.cpp
+++ b/src/janus_io.cpp
@@ -558,15 +558,20 @@ janus_error janus_evaluate_search(janus_gallery_path target, const char *query, 
         if (num_actual_returns < num_requested_returns) {
             int diff = num_requested_returns - num_actual_returns;
             memcpy(similarity_matrix, similarities, sizeof(float)*num_actual_returns);
-            similarity_matrix += num_actual_returns;
+
             for (size_t i=num_actual_returns; i<num_requested_returns; i++) {
-                similarity_matrix[num_queries*num_requested_returns+i] = -std::numeric_limits<float>::max();
+                similarity_matrix[i] = -std::numeric_limits<float>::max();
             }
-            similarity_matrix += diff;
-        } else {
+            similarity_matrix += num_requested_returns;
+        } else if (num_actual_returns == num_requested_returns) {
             memcpy(similarity_matrix, similarities, sizeof(float)*num_actual_returns);
             similarity_matrix += num_actual_returns;
-        }
+        } else {
+	  std::cerr << "Error: Number of search results returned (" << num_actual_returns << ") is greater than number requested ("
+		    << num_requested_returns << "). Likely memory error triggering undefined behavior. Exiting early with error." << std::endl;
+	  return JANUS_UNKNOWN_ERROR;
+	}
+
         for (size_t j=0; j<num_requested_returns; j++) {
             if (j<num_actual_returns) {
                 truth[num_queries*num_requested_returns+j] = (queryMetadata.subjectIDLUT[query_template_id] == targetMetadata.subjectIDLUT[template_ids[j]] ? 0xff : 0x7f);


### PR DESCRIPTION
Hi Janus Dev Team,

In testing our API I ran into a segfault in the case where the number of actual returned search results was less than the number of requested returned search results.

I ended up tracing the problem to a bug in janus_io.cpp. Essentially the similarity_matrix array was being indexed as if the code were accessing it from the start of the array, but really the similarity_matrix pointer was getting incremented during the loop so the indexing should have been relative to the current row.

This pull request fixes that bug. It also adds an extra check to see if the janus_search function ended up returning *more* search results than requested. I just figured if I was making changes I might as well add this check in as well.

Thanks,
Stephen Rawls (ISI)